### PR TITLE
Fix package name on import

### DIFF
--- a/data/python/view_pandas.py
+++ b/data/python/view_pandas.py
@@ -1,6 +1,6 @@
 import pandas
 
-from gtoolkit.gt import gtView
+from gtoolkit_bridge import gtView
 
 #
 # This file contains GToolkit Remote Phlow gtView definitions


### PR DESCRIPTION
The package name for import `gtView` Python annotation seems to have changed. On GT Book page named **Inspecting Python objects with custom inspectors** for example, the import is different from the one in this file. 

So, in `view_pandas.py`, I changed: 

`from gtoolkit.gt import gtView` 

to

`from gtoolkit_bridge import gtView`
